### PR TITLE
Implement configurable color slot machine

### DIFF
--- a/Assets/ColorSlotMachine.cs
+++ b/Assets/ColorSlotMachine.cs
@@ -8,7 +8,8 @@ public class ColorSlotMachine : MonoBehaviour
     public Button spinButton;
     public AchievementModal achievementModal;
 
-    private List<Sprite[]> combos = new List<Sprite[]>();
+    [Tooltip("Predefined wheel combinations")] 
+    public List<Sprite[]> combos = new List<Sprite[]>();
     private int comboIndex = 0;
     private int wheelsStopped = 0;
 
@@ -36,8 +37,14 @@ public class ColorSlotMachine : MonoBehaviour
             wheel.cycleSprites = new[] { shoeB, shoeP, shoeR, shoeW };
         }
 
-        combos.Add(new[] { shoeB, shoeR, shoeW });
-        combos.Add(new[] { shoeP, shoeB, shoeR });
+        if (combos == null || combos.Count == 0)
+        {
+            combos = new List<Sprite[]>
+            {
+                new[] { shoeB, shoeR, shoeW },
+                new[] { shoeP, shoeB, shoeR }
+            };
+        }
 
         if (spinButton != null)
             spinButton.onClick.AddListener(StartSpin);

--- a/Assets/SlotWheelPrefabGenerator.cs
+++ b/Assets/SlotWheelPrefabGenerator.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+/// <summary>
+/// Utility component that assigns a generated symbol prefab to all SlotWheel
+/// instances. The prefab contains all shoe sprites stacked vertically so the
+/// wheels can display them while spinning.
+/// </summary>
+public class SlotWheelPrefabGenerator : MonoBehaviour
+{
+    public SlotWheel[] wheels;
+    public float spacing = 1f;
+
+    void Awake()
+    {
+        if (wheels == null || wheels.Length == 0)
+            return;
+
+        GameObject prefab = CreatePrefab();
+        foreach (var wheel in wheels)
+        {
+            if (wheel != null && wheel.symbolPrefab == null)
+                wheel.symbolPrefab = prefab;
+        }
+    }
+
+    GameObject CreatePrefab()
+    {
+        GameObject root = new GameObject("AutoSymbolPrefab");
+        string[] names = { "Shoes_B", "Shoes_P", "Shoes_R", "Shoes_W" };
+        float offset = 0f;
+        foreach (string n in names)
+        {
+            Sprite sprite = Resources.Load<Sprite>(n);
+            GameObject child = new GameObject(n);
+            child.transform.SetParent(root.transform, false);
+            child.transform.localPosition = new Vector3(0f, offset, 0f);
+            offset -= spacing;
+            var sr = child.AddComponent<SpriteRenderer>();
+            sr.sprite = sprite;
+        }
+        root.SetActive(false);
+        return root;
+    }
+}


### PR DESCRIPTION
## Summary
- add customizable combos in `ColorSlotMachine`
- generate symbol prefabs programmatically for `SlotWheel` instances

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c34be5e24832b9ec06a410550aa89